### PR TITLE
Create update-unbound.yml

### DIFF
--- a/.github/workflows/update-unbound.yml
+++ b/.github/workflows/update-unbound.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_dockerfile.outputs.UPDATE_DOCKERFILE == 'true'
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-unbound-version

--- a/.github/workflows/update-unbound.yml
+++ b/.github/workflows/update-unbound.yml
@@ -3,6 +3,7 @@ name: Update Unbound Dockerfile
 on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight
+  workflow_dispatch:  # Allows manual triggering
 
 jobs:
   update:
@@ -27,13 +28,20 @@ jobs:
           SHA1_HASH=$(curl -sL "$URL/$SHA1" | awk '{print $1}')
           echo "SHA1_HASH=${SHA1_HASH}" >> $GITHUB_ENV
 
-      - name: Update Dockerfile
+      - name: Check if Dockerfile needs update
+        id: check_dockerfile
         run: |
-          sed -i "s/ARG UNBOUND_VERSION=.*/ARG UNBOUND_VERSION=${VERSION}/g" Dockerfile
-          sed -i "s/ARG UNBOUND_SHA256=.*/ARG UNBOUND_SHA256=${SHA1_HASH}/g" Dockerfile
-          sed -i "s|ARG UNBOUND_DOWNLOAD_URL=.*|ARG UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-${VERSION}.tar.gz|g" Dockerfile
+          CURRENT_VERSION=$(grep -oP 'ARG UNBOUND_VERSION=\K[\d.]+' Dockerfile)
+          if [ "$CURRENT_VERSION" != "${{ env.VERSION }}" ]; then
+            echo "Dockerfile needs update"
+            echo "UPDATE_DOCKERFILE=true" >> $GITHUB_ENV
+          else
+            echo "Dockerfile is up to date"
+            echo "UPDATE_DOCKERFILE=false" >> $GITHUB_ENV
+          fi
 
       - name: Create Pull Request
+        if: steps.check_dockerfile.outputs.UPDATE_DOCKERFILE == 'true'
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-unbound.yml
+++ b/.github/workflows/update-unbound.yml
@@ -20,13 +20,13 @@ jobs:
           VERSION=$(curl -sL $URL | grep -oP 'unbound-\K[\d.]+(?=.tar.gz)' 2>/dev/null | tail -1)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Get SHA1 hash
-        id: get_sha1
+      - name: Get SHA256 hash
+        id: get_sha256
         run: |
           URL="https://nlnetlabs.nl/downloads/unbound/"
-          SHA1=$(curl -sL $URL | grep -oP 'unbound-\d+(\.\d+)+\.tar\.gz\.sha1' | tail -1)
-          SHA1_HASH=$(curl -sL "$URL/$SHA1" | awk '{print $1}')
-          echo "SHA1_HASH=${SHA1_HASH}" >> $GITHUB_ENV
+          SHA256=$(curl -sL $URL | grep -oP 'unbound-\d+(\.\d+)+\.tar\.gz\.sha256' | tail -1)
+          SHA256_HASH=$(curl -sL "$URL/$SHA1" | awk '{print $1}')
+          echo "SHA256_HASH=${SHA256_HASH}" >> $GITHUB_ENV
 
       - name: Check if Dockerfile needs update
         id: check_dockerfile

--- a/.github/workflows/update-unbound.yml
+++ b/.github/workflows/update-unbound.yml
@@ -1,0 +1,43 @@
+name: Update Unbound Dockerfile
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get latest Unbound version
+        id: get_version
+        run: |
+          URL="https://nlnetlabs.nl/downloads/unbound/"
+          VERSION=$(curl -sL $URL | grep -oP 'unbound-\K[\d.]+(?=.tar.gz)' 2>/dev/null | tail -1)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Get SHA1 hash
+        id: get_sha1
+        run: |
+          URL="https://nlnetlabs.nl/downloads/unbound/"
+          SHA1=$(curl -sL $URL | grep -oP 'unbound-\d+(\.\d+)+\.tar\.gz\.sha1' | tail -1)
+          SHA1_HASH=$(curl -sL "$URL/$SHA1" | awk '{print $1}')
+          echo "SHA1_HASH=${SHA1_HASH}" >> $GITHUB_ENV
+
+      - name: Update Dockerfile
+        run: |
+          sed -i "s/ARG UNBOUND_VERSION=.*/ARG UNBOUND_VERSION=${VERSION}/g" Dockerfile
+          sed -i "s/ARG UNBOUND_SHA256=.*/ARG UNBOUND_SHA256=${SHA1_HASH}/g" Dockerfile
+          sed -i "s|ARG UNBOUND_DOWNLOAD_URL=.*|ARG UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-${VERSION}.tar.gz|g" Dockerfile
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-unbound-version
+          commit-message: "chore: Update Unbound version to ${{ env.VERSION }}"
+          title: "chore: Update Unbound version to ${{ env.VERSION }}"
+          body: "This pull request updates the Unbound version in the Dockerfile to ${{ env.VERSION }}."

--- a/.github/workflows/update-unbound.yml
+++ b/.github/workflows/update-unbound.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           URL="https://nlnetlabs.nl/downloads/unbound/"
           SHA256=$(curl -sL $URL | grep -oP 'unbound-\d+(\.\d+)+\.tar\.gz\.sha256' | tail -1)
-          SHA256_HASH=$(curl -sL "$URL/$SHA1" | awk '{print $1}')
+          SHA256_HASH=$(curl -sL "$URL/$SHA256" | awk '{print $1}')
           echo "SHA256_HASH=${SHA256_HASH}" >> $GITHUB_ENV
 
       - name: Check if Dockerfile needs update

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TAG='latest'
 FROM debian:bullseye as unbound
 
 ARG UNBOUND_VERSION=1.20.0
-ARG UNBOUND_SHA256=e1963919e49a64151bed2475e470042b631950fb
+ARG UNBOUND_SHA256=56b4ceed33639522000fd96775576ddf8782bb3617610715d7f1e777c5ec1dbf
 ARG UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-1.20.0.tar.gz
 
 WORKDIR /tmp/src


### PR DESCRIPTION
Hey, this pr creates a github workflow, which runs once per day and checks, if a new version of unbound has been found. If it does, it creates a new pr which updates the dockerfile accordingly to reflect the new unbound release.

I have noted in my original pr for adding unbound, that this is still needed, but as i am not familiar with github actions, i cant do this. i have created this workflow file using chatgpt and i have tested it on my fork, and it seems to work there. I have noticed, that there is a new version of unbound (1.20.0), so there is a need to update unbound in this container aswel